### PR TITLE
Redirect users to login page when accessing forbidden link

### DIFF
--- a/lib/blog/authenticable.ex
+++ b/lib/blog/authenticable.ex
@@ -25,7 +25,7 @@ defmodule Blog.Authenticable do
     unless current_user(conn) do
       conn
       |> put_flash(:alert, "You must be authenticated to proceed")
-      |> redirect(to: "/")
+      |> redirect(to: "/users/sign_in")
       |> halt
     else
       conn


### PR DESCRIPTION
Links that require authentication will redirect to the login page instead of the home page.
